### PR TITLE
feat: handle result manually using isErr or isOk [no issue]

### DIFF
--- a/docs/rules/must-use-result.md
+++ b/docs/rules/must-use-result.md
@@ -14,11 +14,11 @@ Examples of **incorrect** code:
 
 // result without unwrapOr, match or any error handler
 const result = getResult();
-result.map(() => {})
+result.map(() => {});
 
 // result used just as parameter
-const v = getResult()
-externaFunction(v)
+const v = getResult();
+externaFunction(v);
 ```
 
 Examples of **correct** code:
@@ -26,14 +26,25 @@ Examples of **correct** code:
 ```js
 /*eslint neverthrow/must-use-result: error */
 
-const result = getResult()
+const result = getResult();
 
-result.unwrapOr()
+result.unwrapOr();
 
 // after call a map
-const result = getResult()
+const result = getResult();
 
-result.map(() => {}).unwrapOr('')
+result.map(() => {}).unwrapOr('');
+
+// handled manually
+const result = getResult();
+
+if (result.isErr()) {
+  console.error('failure', result.error);
+}
+
+if (result.isOk()) {
+  console.log('success', result.value);
+}
 ```
 
 ## Options

--- a/tests/rules/must-use.ts
+++ b/tests/rules/must-use.ts
@@ -102,6 +102,46 @@ new TSESLint.RuleTester({
     `
     ),
     injectResult(
+      'Call isErr',
+      `
+      const result = getResult()
+
+      if (result.isErr()) {
+        console.error('failure')
+      }
+    `
+    ),
+    injectResult(
+      'Call isOk',
+      `
+      const result = getResult()
+
+      if (result.isOk()) {
+        console.log('success')
+      }
+    `
+    ),
+    injectResult(
+      'Call isErr and use error',
+      `
+      const result = getResult()
+
+      if (result.isErr()) {
+        console.error(result.error)
+      }
+    `
+    ),
+    injectResult(
+      'Call isOk and use value',
+      `
+      const result = getResult()
+
+      if (result.isOk()) {
+        console.log(result.value)
+      }
+    `
+    ),
+    injectResult(
       'Return result from function',
       `
       function main() {


### PR DESCRIPTION
We want rule `must-use-result` to support manually result handlings, such as:

```js
const result = getResult();

if (result.isErr()) {
  console.error('failure', result.error);
}
```

or

```js
const result = getResult();

if (result.isOk()) {
  console.log('success', result.value);
}
```